### PR TITLE
Biblatex support: recognize addbibresource

### DIFF
--- a/ftplugin/latex-suite/texviewer.vim
+++ b/ftplugin/latex-suite/texviewer.vim
@@ -567,14 +567,14 @@ function! Tex_ScanFileForCite(prefix)
 	" First find out if this file has a \bibliography command in it. If so,
 	" assume that this is the only file in the project which defines a
 	" bibliography.
-	if search('\\\(no\)\?bibliography{', 'w')
+	if search('\\\(no\)\?\(bibliography\|addbibresource\){', 'w')
 		call Tex_Debug('Tex_ScanFileForCite: found bibliography command in '.bufname('%'), 'view')
 		" convey that we have found a bibliography command. we do not need to
 		" proceed any further.
 		let foundCiteFile = 1
 
 		" extract the bibliography filenames from the command.
-		let bibnames = matchstr(getline('.'), '\\\(no\)\?bibliography{\zs.\{-}\ze}')
+		let bibnames = matchstr(getline('.'), '\\\(no\)\?\(bibliography\|addbibresource\){\zs.\{-}\ze}')
 		let bibnames = substitute(bibnames, '\s', '', 'g')
 
 		call Tex_Debug('trying to search through ['.bibnames.']', 'view')
@@ -859,12 +859,12 @@ function! Tex_FindBibFiles()
 	split
 	exec 'silent! e '.fnameescape(mainfname)
 
-	if search('\\\(no\)\?bibliography{', 'w')
+	if search('\\\(no\)\?\(bibliography\|addbibresource\){', 'w')
 
 		call Tex_Debug('Tex_FindBibFiles: found bibliography command in '.bufname('%'), 'view')
 
 		" extract the bibliography filenames from the command.
-		let bibnames = matchstr(getline('.'), '\\\(no\)\?bibliography{\zs.\{-}\ze}')
+		let bibnames = matchstr(getline('.'), '\\\(no\)\?\(bibliography\|addbibresource\){\zs.\{-}\ze}')
 		let bibnames = substitute(bibnames, '\s', '', 'g')
 
 		call Tex_Debug(':Tex_FindBibFiles: trying to search through ['.bibnames.']', 'view')


### PR DESCRIPTION
Patch taken from
http://sourceforge.net/tracker/?func=detail&aid=3315923&group_id=52322&atid=466458
## Copied description:

When using biblatex the bib file is included by \addbibresource{library.bib}
Vim-Latex does not recognize this command and so the outline does not
work.

The attached tiny patch replaces the search functions in the texviewer.
It is a quite simple patch, just works for this special case and makes
latex suite recognize the bib file.

The diff is against the actual git master branch.
