### PR TITLE
Fix #9 restoring of cwd

### DIFF
--- a/ftplugin/latex-suite/compiler.vim
+++ b/ftplugin/latex-suite/compiler.vim
@@ -40,7 +40,7 @@ function! Tex_SetTeXCompilerTarget(type, target)
 		let s:target = target
 
 	else
-		let s:origdir = fnameescape(getcwd())
+		let l:origdir = fnameescape(getcwd())
 		exe 'cd '.fnameescape(expand('%:p:h'))
 		if !Tex_GetVarValue('Tex_UseMakefile') || (glob('makefile*') == '' && glob('Makefile*') == '')
 			if has('gui_running')
@@ -62,7 +62,7 @@ function! Tex_SetTeXCompilerTarget(type, target)
 			echomsg 'Assuming target is for makefile'
 			let s:target = target
 		endif
-		exe 'cd '.s:origdir
+		exe 'cd '.l:origdir
 	endif
 endfunction
 
@@ -97,7 +97,7 @@ function! Tex_CompileLatex()
 	" close any preview windows left open.
 	pclose!
 
-	let s:origdir = fnameescape(getcwd())
+	let l:origdir = fnameescape(getcwd())
 
 	" Find the main file corresponding to this file. Always cd to the
 	" directory containing the file to avoid problems with the directory
@@ -142,7 +142,7 @@ function! Tex_CompileLatex()
 	endif
 	redraw!
 
-	exe 'cd '.s:origdir
+	exe 'cd '.l:origdir
 endfunction " }}}
 " Tex_RunLaTeX: compilation function {{{
 " this function runs the latex command on the currently open file. often times
@@ -158,7 +158,7 @@ function! Tex_RunLaTeX()
 	call Tex_Debug('+Tex_RunLaTeX, b:fragmentFile = '.exists('b:fragmentFile'), 'comp')
 
 	let dir = expand("%:p:h").'/'
-	let s:origdir = fnameescape(getcwd())
+	let l:origdir = fnameescape(getcwd())
 	call Tex_CD(expand("%:p:h"))
 
 	let initTarget = s:target
@@ -209,7 +209,7 @@ function! Tex_RunLaTeX()
 	let s:origwinnum = winnr()
 	call Tex_SetupErrorWindow()
 
-	exe 'cd '.s:origdir
+	exe 'cd '.l:origdir
 	call Tex_Debug("-Tex_RunLaTeX", "comp")
 endfunction
 
@@ -224,7 +224,7 @@ function! Tex_ViewLaTeX()
 		return
 	end
 
-	let s:origdir = fnameescape(getcwd())
+	let l:origdir = fnameescape(getcwd())
 
 	" If b:fragmentFile is set, it means this file was compiled as a fragment
 	" using Tex_PartCompile, which means that we want to ignore any
@@ -306,7 +306,7 @@ function! Tex_ViewLaTeX()
 		redraw!
 	endif
 
-	exe 'cd '.s:origdir
+	exe 'cd '.l:origdir
 endfunction
 
 " }}}
@@ -332,7 +332,7 @@ function! Tex_ForwardSearchLaTeX()
 	endif
 	let viewer = Tex_GetVarValue('Tex_ViewRule_'.s:target)
 
-	let s:origdir = fnameescape(getcwd())
+	let l:origdir = fnameescape(getcwd())
 
 	let mainfname = Tex_GetMainFileName(':t')
 	let mainfnameRoot = fnamemodify(Tex_GetMainFileName(), ':t:r')
@@ -422,7 +422,7 @@ function! Tex_ForwardSearchLaTeX()
 		redraw!
 	endif
 
-	exe 'cd '.s:origdir
+	exe 'cd '.l:origdir
 endfunction
 
 " }}}
@@ -508,7 +508,7 @@ endfunction " }}}
 function! Tex_CompileMultipleTimes()
 	" Just extract the root without any extension because we want to construct
 	" the log file names etc from it.
-	let s:origdir = fnameescape(getcwd())
+	let l:origdir = fnameescape(getcwd())
 	let mainFileName_root = Tex_GetMainFileName(':p:t:r')
 	call Tex_CD(Tex_GetMainFileName(':p:h'))
 
@@ -611,7 +611,7 @@ function! Tex_CompileMultipleTimes()
 	" emptied because of bibtex/makeindex being run as the last step.
 	exec 'silent! cfile '.mainFileName_root.'.log'
 
-	exe 'cd '.s:origdir
+	exe 'cd '.l:origdir
 endfunction " }}}
 " Tex_GetAuxFile: get the contents of the AUX file {{{
 " Description: get the contents of the AUX file recursively including any

--- a/ftplugin/latex-suite/main.vim
+++ b/ftplugin/latex-suite/main.vim
@@ -418,7 +418,7 @@ function! Tex_GetMainFileName(...)
 		return retval
 	endif
 
-	let s:origdir = fnameescape(getcwd())
+	let l:origdir = fnameescape(getcwd())
 
 	let dirmodifier = '%:p:h'
 	let dirLast = fnameescape(expand(dirmodifier))
@@ -449,7 +449,7 @@ function! Tex_GetMainFileName(...)
 		let lheadfile = expand('%'.modifier)
 	endif
 
-	exe 'cd '.s:origdir
+	exe 'cd '.l:origdir
 
 	" NOTE: The caller of this function needs to escape the file name with
 	"       fnameescape() . The reason its not done here is that escaping is not

--- a/ftplugin/latex-suite/texproject.vim
+++ b/ftplugin/latex-suite/texproject.vim
@@ -34,7 +34,7 @@ endfunction " }}}
 " Tex_ProjectLoad: loads the .latexmain file {{{
 " Description: If a *.latexmain file exists, then sources it
 function! Tex_ProjectLoad()
-	let s:origdir = fnameescape(getcwd())
+	let l:origdir = fnameescape(getcwd())
 	exe 'cd '.fnameescape(expand('%:p:h'))
 
 	if glob(Tex_GetMainFileName(':p').'.latexmain') != ''
@@ -42,7 +42,7 @@ function! Tex_ProjectLoad()
                exec 'source '.fnameescape(Tex_GetMainFileName().'.latexmain')
 	endif
 	
-	exe 'cd '.s:origdir
+	exe 'cd '.l:origdir
 endfunction " }}}
 
 augroup LatexSuite

--- a/ftplugin/latex-suite/texviewer.vim
+++ b/ftplugin/latex-suite/texviewer.vim
@@ -44,7 +44,7 @@ function! Tex_Complete(what, where)
 	" Change to the directory of the file being edited before running all the
 	" :grep commands. We will change back to the original directory after we
 	" finish with the grep.
-	let s:origdir = fnameescape(getcwd())
+	let l:origdir = fnameescape(getcwd())
 	exe 'cd '.fnameescape(expand('%:p:h'))
 
 	unlet! s:type
@@ -124,12 +124,12 @@ function! Tex_Complete(what, where)
 			if has('python') && Tex_GetVarValue('Tex_UsePython') 
 				\ && Tex_GetVarValue('Tex_UseCiteCompletionVer2') == 1
 
-				exe 'cd '.s:origdir
+				exe 'cd '.l:origdir
 				silent! call Tex_StartCiteCompletion()
 
 			elseif Tex_GetVarValue('Tex_UseJabref') == 1
 
-				exe 'cd '.s:origdir
+				exe 'cd '.l:origdir
 				let g:Remote_WaitingForCite = 1
 				let citation = input('Enter citation from jabref (<enter> to leave blank): ')
 				let g:Remote_WaitingForCite = 0
@@ -366,7 +366,7 @@ function! s:Tex_SetupCWindow(...)
 	if exists("s:type") && s:type =~ 'ref\|cite'
 		exec 'nnoremap <buffer> <silent> <cr> '
 			\ .':set scrolloff='.s:scrollOffVal.'<CR>'
-			\ .':cd '.s:origdir.'<CR>'
+			\ .':cd '.l:origdir.'<CR>'
 			\ .':silent! call <SID>Tex_CompleteRefCiteCustom("'.s:type.'")<CR>'
 
 	else
@@ -374,7 +374,7 @@ function! s:Tex_SetupCWindow(...)
 		" windows
 		exec 'nnoremap <buffer> <silent> <cr> '
 			\ .':set scrolloff='.s:scrollOffVal.'<CR>'
-			\ .':cd '.s:origdir.'<CR>'
+			\ .':cd '.l:origdir.'<CR>'
 			\ .':call <SID>Tex_GoToLocation()<cr>'
 
 	endif
@@ -386,7 +386,7 @@ function! s:Tex_SetupCWindow(...)
 	" Exit the quickfix window without doing anything.
 	exe 'nnoremap <buffer> <silent> q '
 		\ .':set scrolloff='.s:scrollOffVal.'<CR>'
-		\ .':cd '.s:origdir.'<CR>'
+		\ .':cd '.l:origdir.'<CR>'
 		\ .':call Tex_CloseSmallWindows()<CR>'
 
 endfunction " }}}
@@ -797,10 +797,10 @@ function! Tex_StartOutlineCompletion()
     call Tex_SetupOutlineSyntax()
 
 	exec 'nnoremap <buffer> <cr> '
-		\ .':cd '.s:origdir.'<CR>'
+		\ .':cd '.l:origdir.'<CR>'
 		\ .':call Tex_FinishOutlineCompletion()<CR>'
 	exec 'nnoremap <buffer> q '
-		\ .':cd '.s:origdir.'<CR>'
+		\ .':cd '.l:origdir.'<CR>'
 		\ .':close<CR>'
 		\ .':call Tex_SwitchToInsertMode()<CR>'
 


### PR DESCRIPTION
The s:origdir variable was local to the source file. Since all functions used
the same name for the variable to save the old working directory, restoring did
not work with nested function calls as one call would overwrite the restore
value of a function invocation higher up the stack.

This was fixed by replacing s:origdir with a local variable l:origdir
