### PR TITLE
Fixed directory of tempfile while part-compiling (under windows at least...

### DIFF
--- a/ftplugin/latex-suite/main.vim
+++ b/ftplugin/latex-suite/main.vim
@@ -560,7 +560,7 @@ endfunction " }}}
 "              us to create temporary files in a specified directory.
 function! Tex_GetTempName(dirname)
 	let prefix = 'latexSuiteTemp'
-	let slash = (a:dirname =~ '[\\\/]$' ? '' : '/')
+	let slash = (a:dirname =~ '\\$\|/$' ? '' : '/')
 	let i = 0
 	while filereadable(a:dirname.slash.prefix.i.'.tex') && i < 1000
 		let i = i + 1


### PR DESCRIPTION
When compiling a part of a file under windows, the temp-file was placed one directory above of where it should have been. I fixed this by appending a '/' (slash) at the end of the command "expand('%:p:h')" that gives the name of the current directory. Now it is working as expected.
