### PR TITLE
Added simple biber support for biblatex

### DIFF
--- a/ftplugin/latex-suite/compiler.vim
+++ b/ftplugin/latex-suite/compiler.vim
@@ -581,9 +581,16 @@ function! Tex_CompileMultipleTimes()
 			let needToRerun = 1
 		endif
 
+		" Determine if the bibliography should be compiled via bibtex or biber
+		if Tex_GetVarValue('Tex_BibtexFlavor') == "biber"
+			let temp_bibfile = '.bcf'
+		else
+			let temp_bibfile = '.aux'
+		endif
+
 		" The first time we see if we need to run bibtex and if the .bbl file
 		" changes, we will rerun latex.
-		if runCount == 0 && Tex_IsPresentInFile('\\bibdata', mainFileName_root.'.aux')
+		if runCount == 0 && Tex_IsPresentInFile('bibdata', mainFileName_root.temp_bibfile)
 			let bibFileName = mainFileName_root.'.bbl'
 
 			let biblinesBefore = Tex_CatFile(bibFileName)


### PR DESCRIPTION
As I sometimes have to switch between the two biblatex backends bibtex and biber for different reports, I added some basic biber support to vim-latex.

In the moment it is not sufficient to adjust `g:Tex_BibtexFlavor` as unfortunately biber and bibtex use different files to manage their bibliography. Therefor I just added a small if to decide which file should be accessed based on the used bibliography.

By default it still uses bibtex, but the advantage now is, that it is sufficient to change the value from `g:Tex_BibtexFlavor` from `'bibtex'` to `'biber'` to change the biblatex backend.