### PR TITLE
Fix synced forward search for Skim installed by Homebrew Cask on MacOSX

### DIFF
--- a/ftplugin/latex-suite/compiler.vim
+++ b/ftplugin/latex-suite/compiler.vim
@@ -364,20 +364,24 @@ function! Tex_ForwardSearchLaTeX()
 
 		let execString .= Tex_Stringformat('start %s -s %s%s %s', viewer, linenr, sourcefile, mainfnameRoot)
 
-	elseif (has('macunix') && (viewer =~ '^ *\(Skim\|PDFView\|TeXniscope\)\( \|$\)'))
+	elseif (has('macunix') && (viewer =~ '\(Skim\|PDFView\|TeXniscope\)'))
 		" We're on a Mac using a traditional Mac viewer
 
-		if viewer =~ '^ *Skim'
+		if viewer =~ 'Skim'
 
+			if executable('displayline')
+				let execString .= 'displayline '
+			else
 				let execString .= '/Applications/Skim.app/Contents/SharedSupport/displayline '
+			endif
 				let execString .= join([linenr, target_file, sourcefileFull])
 
-		elseif viewer =~ '^ *PDFView'
+		elseif viewer =~ 'PDFView'
 
 				let execString .= '/Applications/PDFView.app/Contents/MacOS/gotoline.sh '
 				let execString .= join([linenr, target_file, sourcefileFull])
 
-		elseif viewer =~ '^ *TeXniscope'
+		elseif viewer =~ 'TeXniscope'
 
 				let execString .= '/Applications/TeXniscope.app/Contents/Resources/forward-search.sh '
 				let execString .= join([linenr, sourcefileFull, target_file])


### PR DESCRIPTION
For the Skim PDF viewer, fix viewer pattern and path to the executable script `displayline` as installed by Homebrew Cask.