### PR TITLE
Fix macOS detection in scripts on High Sierra.

### DIFF
--- a/ftplugin/latex-suite/compiler.vim
+++ b/ftplugin/latex-suite/compiler.vim
@@ -33,7 +33,7 @@ function! Tex_SetTeXCompilerTarget(type, target)
 	elseif Tex_GetVarValue('Tex_'.a:type.'RuleComplete_'.target) != ''
 		let s:target = target
 
-	elseif a:type == 'View' && has('macunix')
+	elseif a:type == 'View' && has('osx')
 		" On the mac, we can have empty view rules, so do not complain when
 		" both Tex_ViewRule_target and Tex_ViewRuleComplete_target are
 		" empty. On other platforms, we will complain... see below.
@@ -250,7 +250,7 @@ function! Tex_ViewLaTeX()
 		" that this particular vim and yap are connected.
 		let execString = 'start '.s:viewer.' "$*.'.s:target.'"'
 
-	elseif (has('macunix') && Tex_GetVarValue('Tex_TreatMacViewerAsUNIX') != 1)
+	elseif (has('osx') && Tex_GetVarValue('Tex_TreatMacViewerAsUNIX') != 1)
 
 		if strlen(s:viewer)
 			let appOpt = '-a '
@@ -379,7 +379,7 @@ function! Tex_ForwardSearchLaTeX()
 			let execString .= Tex_Stringformat('start %s %s -forward-search %s %s', viewer, target_file, sourcefileFull, linenr)
 		endif	
 
-	elseif (has('macunix') && (viewer =~ '\(Skim\|PDFView\|TeXniscope\)'))
+	elseif (has('osx') && (viewer =~ '\(Skim\|PDFView\|TeXniscope\)'))
 		" We're on a Mac using a traditional Mac viewer
 
 		if viewer =~ 'Skim'

--- a/ftplugin/latex-suite/custommacros.vim
+++ b/ftplugin/latex-suite/custommacros.vim
@@ -11,7 +11,7 @@
 let s:path = expand('<sfile>:p:h')
 
 " Set path to macros dir dependent on OS {{{
-if has("unix") || has("macunix")
+if has("unix") || has("osx")
 	let s:macrodirpath = $HOME."/.vim/ftplugin/latex-suite/macros/"
 elseif has("win32")
 	if exists("$HOME")

--- a/ftplugin/latex-suite/texrc
+++ b/ftplugin/latex-suite/texrc
@@ -83,7 +83,7 @@ TexLet g:Tex_DebugLog = ''
 " generating a .dvi file. Change this line if you want to set another default.
 " NOTE: Make sure that a target for this format exists in the 'Compiler rules'
 "       section below and is set up properly for your system.
-if has('macunix')
+if has('osx')
 	TexLet g:Tex_DefaultTargetFormat = 'pdf'
 else
 	TexLet g:Tex_DefaultTargetFormat = 'dvi'
@@ -140,7 +140,7 @@ if has('win32')
 	TexLet g:Tex_ViewRule_ps = 'gsview32'
 	TexLet g:Tex_ViewRule_pdf = 'AcroRd32'
 	TexLet g:Tex_ViewRule_dvi = 'yap -1'
-elseif has('macunix')
+elseif has('osx')
 	" Let the system pick.  If you want, you can override the choice here.
 	TexLet g:Tex_ViewRule_ps = ''
 	TexLet g:Tex_ViewRule_pdf = ''


### PR DESCRIPTION
On macOS High Sierra, the system vim (/usr/bin/vim) is compiled as a
"Normal Version" binary without the "macunix" feature, and
has("macunix") returns 0.  In the scripts, this breaks the code guarded
by such condition, intended to work on macOS platform.  For example, the
platform- and configuration-specific forward search with <Leader>ls is
broken.

To fix this, use has("osx") in the place of has("macunix").  The former
is more inclusive than the latter and will return 1 on the High Sierra
system vim, therefore correctly identifying the platform.

The Homebrew vim is compiled as "Huge Version" binary, and
has("macunix") works in it.  Therefore, the change is not necessary, but
still compatible.